### PR TITLE
[chore] update image tag to latest version

### DIFF
--- a/neo4j.yml
+++ b/neo4j.yml
@@ -48,7 +48,7 @@ db:
       value: 7474
     image:
       type: string
-      value: 5.5
+      value: latest
   services:
     admin:
       port: 7474


### PR DESCRIPTION
This pull request includes a small change to the `neo4j.yml` file. The change updates the `image` value from `5.5` to `latest`.

* [`db/neo4j.yml`](diffhunk://#diff-cf75a7f9375a3216c4ea829ad07b879c89efeff56daa80497585c92148948ee9L51-R51): Updated the `image` value to `latest` to ensure the use of the most recent version.